### PR TITLE
Handle DNS polution of Jsdelivr

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
     <title>Document</title>
@@ -11,17 +11,17 @@
     />
     <link
       rel="stylesheet"
-      href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css"
+      href="//fastly.jsdelivr.net/npm/docsify@4/lib/themes/vue.css"
     />
     <!-- latex -->
     <link
       rel="stylesheet"
-      href="//cdn.jsdelivr.net/npm/katex@latest/dist/katex.min.css"
+      href="//fastly.jsdelivr.net/npm/katex@latest/dist/katex.min.css"
     />
     <!-- dark mode -->
     <link
       rel="stylesheet"
-      href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
+      href="//fastly.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
       title="docsify-darklight-theme"
       type="text/css"
     />
@@ -37,14 +37,14 @@
     <!-- slidebar collapse -->
     <link
       rel="stylesheet"
-      href="//cdn.jsdelivr.net/npm/docsify-sidebar-collapse/dist/sidebar.min.css"
+      href="//fastly.jsdelivr.net/npm/docsify-sidebar-collapse/dist/sidebar.min.css"
     />
     <!-- mermaid -->
     <link
       rel="stylesheet"
-      href="//cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.css"
+      href="//fastly.jsdelivr.net/npm/mermaid/dist/mermaid.min.css"
     />
-    <script src="//cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+    <script src="//fastly.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
   </head>
   <body>
     <div id="app"></div>
@@ -81,16 +81,16 @@
       };
     </script>
     <!-- Docsify v4 -->
-    <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+    <script src="//fastly.jsdelivr.net/npm/docsify@4"></script>
     <!-- docsify-katex for latex -->
-    <script src="//cdn.jsdelivr.net/npm/docsify-katex@latest/dist/docsify-katex.js"></script>
+    <script src="//fastly.jsdelivr.net/npm/docsify-katex@latest/dist/docsify-katex.js"></script>
     <!-- dark mode -->
-    <script src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"></script>
+    <script src="//fastly.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"></script>
     <!-- copy to clipboard -->
-    <script src="//cdn.jsdelivr.net/npm/docsify-copy-code/dist/docsify-copy-code.min.js"></script>
+    <script src="//fastly.jsdelivr.net/npm/docsify-copy-code/dist/docsify-copy-code.min.js"></script>
     <!-- markmap for mind map -->
     <script src="//unpkg.com/docsify-mindmap/dist/docsify-mindmap.min.js"></script>
     <!-- slidebar collapse -->
-    <script src="//cdn.jsdelivr.net/npm/docsify-sidebar-collapse/dist/docsify-sidebar-collapse.min.js"></script>
+    <script src="//fastly.jsdelivr.net/npm/docsify-sidebar-collapse/dist/docsify-sidebar-collapse.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Something goes wrong while accessing resources via *cdn.jsdelivr.net*.

![image](https://user-images.githubusercontent.com/76473505/169634831-676b66db-1745-40bf-9d3b-cba63221caa3.png)

When I change to *fastly.jsdelivr.net*, it works, at least, for me.